### PR TITLE
Update README with ngrok instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Once you're done, it'll ask you to remove the install folder.  Do do that, SSH i
 ## Basic Usage
 Just fire up the browser of your choice and take a peek at http://localhost:8081/prestashop. If you want to check out the database, we installed phpMyAdmin, too, so just hit http://localhost:8081/phpmyadmin and use the same root/abc123 to log in.
 
+## Advanced Usage
+To expose your local prestashop to the internet, you can use ngrok.com where signing up is free and gets you access to custom subdomains. So you can run something like `./ngrok -subdomain psMyFirstName 8081` after `vagrant up` which will tunnel and connect your local server to the internet. This means it will let your teammates reach your server publically at http://psMyFirstName.ngrok.com/prestashop
+
 ## Development
 Back in your host operating system, notice that there is a new directory in the same directory as this README file called "prestashop".  This is the very same directory that your new vagrant sees, and any edits made from either within the vagrant or from your host operating system will be seen in both places. This means you can edit using any tools in your host OS that you please!
 


### PR DESCRIPTION
After getting to the last part where http://localhost:8081/prestashop is up and running. Instructions could be added to use https://ngrok.com/ and allow external use via commands like: `./ngrok -subdomain psMyFirstName 8081` that allow anyone to reach your server at http://psMyFirstName.ngrok.com/prestashop

This will blow away your co-workers with its ease of use!
